### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 secondary-dex-gradle
 ====================
-#UPDATE
+# UPDATE
 Since Google has officially released a comprehensive mechanism to [Build Apps with more than 65,000 methods](http://developer.android.com/tools/building/multidex.html), this project is no longer going to be maintained.
 
 Please refer to the official Google Docs on this issue.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
